### PR TITLE
Avoid setting empty node addresses

### DIFF
--- a/ibm/ibm_instances.go
+++ b/ibm/ibm_instances.go
@@ -72,11 +72,16 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 	if len(externalIP) == 0 {
 		externalIP = nodeMd.InternalIP
 	}
-	// Build and return node nodeaddresses.
-	return []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: nodeMd.InternalIP},
-		{Type: v1.NodeExternalIP, Address: externalIP},
-	}, nil
+
+	// add ips to node address only if they are non-empty
+	var nodeAddress []v1.NodeAddress
+	if len(nodeMd.InternalIP) > 0 {
+		nodeAddress = append(nodeAddress, v1.NodeAddress{Type: v1.NodeInternalIP, Address: nodeMd.InternalIP})
+	}
+	if len(externalIP) > 0 {
+		nodeAddress = append(nodeAddress, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
+	}
+	return nodeAddress, nil
 }
 
 // NodeAddressesByProviderID returns the addresses of the specified instance.
@@ -249,9 +254,14 @@ func (c *Cloud) nodeAddressesV2(ctx context.Context, nodeMD NodeMetadata) []v1.N
 	if len(externalIP) == 0 {
 		externalIP = nodeMD.InternalIP
 	}
-	// Build and return node nodeaddresses.
-	return []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: nodeMD.InternalIP},
-		{Type: v1.NodeExternalIP, Address: externalIP},
+
+	// add ips to node address only if they are non-empty
+	var nodeAddress []v1.NodeAddress
+	if len(nodeMD.InternalIP) > 0 {
+		nodeAddress = append(nodeAddress, v1.NodeAddress{Type: v1.NodeInternalIP, Address: nodeMD.InternalIP})
 	}
+	if len(externalIP) > 0 {
+		nodeAddress = append(nodeAddress, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
+	}
+	return nodeAddress
 }


### PR DESCRIPTION
This PR contains the changes to avoid setting internal ip to emtpy string incase CCM fails to find internal ip of machine.