### PR TITLE
Changed variable declaration method

### DIFF
--- a/ibm/ibm_instances.go
+++ b/ibm/ibm_instances.go
@@ -72,9 +72,8 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 	if len(externalIP) == 0 {
 		externalIP = nodeMd.InternalIP
 	}
-
-	// add ips to node address only if they are non-empty
-	var nodeAddress []v1.NodeAddress
+	// Build and return node nodeaddresses - if they are non-empty
+	nodeAddress := []v1.NodeAddress{}
 	if len(nodeMd.InternalIP) > 0 {
 		nodeAddress = append(nodeAddress, v1.NodeAddress{Type: v1.NodeInternalIP, Address: nodeMd.InternalIP})
 	}
@@ -254,9 +253,8 @@ func (c *Cloud) nodeAddressesV2(ctx context.Context, nodeMD NodeMetadata) []v1.N
 	if len(externalIP) == 0 {
 		externalIP = nodeMD.InternalIP
 	}
-
-	// add ips to node address only if they are non-empty
-	var nodeAddress []v1.NodeAddress
+	// Build and return node nodeaddresses - if they are non-empty
+	nodeAddress := []v1.NodeAddress{}
 	if len(nodeMD.InternalIP) > 0 {
 		nodeAddress = append(nodeAddress, v1.NodeAddress{Type: v1.NodeInternalIP, Address: nodeMD.InternalIP})
 	}


### PR DESCRIPTION
With the latest changes included into [cloud-provider-ibm](https://github.com/openshift/cloud-provider-ibm/pull/38) to avoid overriding empty ip, There is a [change](https://github.com/openshift/cloud-provider-powervs/blob/f1e96e942eab55fa3f090661a11aa0f6d93c31f9/ibm/ibm_instances.go#L77) in which the declared its causing UT to fail and avoiding merging synch PR: https://github.com/openshift/cloud-provider-powervs/pull/11