### PR TITLE
Revert build_image to the one currently specified in release repo

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.14
+  tag: rhel-8-golang-1.18-openshift-4.11


### PR DESCRIPTION
This should be reverted to the latest version when we do next rebase.