### PR TITLE
Revert images golang 1.18

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.14
+  tag: rhel-8-release-golang-1.18-openshift-4.11

--- a/openshift-hack/images/Dockerfile.openshift
+++ b/openshift-hack/images/Dockerfile.openshift
@@ -1,11 +1,11 @@
 # Build IBM cloud controller manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS ccm-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS ccm-builder
 WORKDIR /build
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o ibm-cloud-controller-manager .
 
 # Assemble the final image
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM registry.ci.openshift.org/ocp/4.11:base
 LABEL description="IBM Cloud Controller Manager"
 COPY --from=ccm-builder /build/ibm-cloud-controller-manager /bin/ibm-cloud-controller-manager
 ENTRYPOINT [ "/bin/ibm-cloud-controller-manager" ]


### PR DESCRIPTION
Currently, the images are being built using go 1.20, but the unit tests are being run using go 1.18 build root specified in the release repo. Updating the release repo to use go 1.20 build root from local .ci-operator.yaml causes the tests to fail. 

This PR reverts build images to go 1.18. Allowing the release repo PR to switch to use .ci-operator.yaml. Afterward, we can update back go 1.20 in the next rebase.