### PR TITLE
UPSTREAM: <carry>: Add check for valid Power VS instance id

### DIFF
--- a/ibm/ibm_powervs_client.go
+++ b/ibm/ibm_powervs_client.go
@@ -175,6 +175,9 @@ func (p *ibmPowerVSClient) populateNodeMetadata(nodeName string, node *NodeMetad
 	if pvsInstance == nil {
 		return errors.New("Could not retrieve a Power instance: name=" + nodeName)
 	}
+	if pvsInstance.PvmInstanceID == nil || *pvsInstance.PvmInstanceID == "" {
+		return fmt.Errorf("could not retrieve valid instance id for Power instance name: %s instance id: %v", nodeName, pvsInstance.PvmInstanceID)
+	}
 	node.WorkerID = *pvsInstance.PvmInstanceID
 	klog.Infof("Node %s worker id is %s", nodeName, node.WorkerID)
 


### PR DESCRIPTION
In one of the cluster we found a weird issue where provider id for only one of master nodes was not set properly.

For Power VS the provider id format is 
```
ibmpowervs://<region>/<zone>/<service_instance_id>/<powervs_machine_id>
```

Valid provider id for master-0 node

```
$ oc describe node rdr-hamzy-test-mon01-d7jf4-master-0 | grep ProviderID

ProviderID:                               ibmpowervs://mon/mon01/4a067319-fcc5-41ce-9ba8-d7ca2523789a/9be6ac21-5e3f-4b76-b29a-48f31b6ab0f7
```

Invalid provider id for master-1 node
```
$ oc describe node rdr-hamzy-test-mon01-d7jf4-master-1 | grep ProviderID

ProviderID:                               ibmpowervs://mon/mon01/4a067319-fcc5-41ce-9ba8-d7ca2523789a/
```

the powervs_machine_id is missing.

On checking found that ccm container was restarted once with exit code 1
```
$ oc -n openshift-cloud-controller-manager get pods

NAME                                                READY   STATUS    RESTARTS      AGE
powervs-cloud-controller-manager-5dd86976b5-fwjng   1/1     Running   1 (10h ago)   11h
powervs-cloud-controller-manager-5dd86976b5-mpncz   1/1     Running   0             11h


$ oc -n openshift-cloud-controller-manager describe pod powervs-cloud-controller-manager-5dd86976b5-fwjng

Last State:     Terminated
  Reason:       Error
  Exit Code:    1
  Started:      Fri, 30 Jun 2023 02:01:28 +0530
  Finished:     Fri, 30 Jun 2023 02:14:39 +0530

```

Suspecting a case when Power VS instance id is nil or empty value might have caused this issue. 
