### PR TITLE
MULTIARCH-4610: UPSTREAM: <carry>: Override service endpoints

### DIFF
--- a/ibm/ibm.go
+++ b/ibm/ibm.go
@@ -109,6 +109,10 @@ type Provider struct {
 	IamEndpointOverride string `gcfg:"iamEndpointOverride"`
 	// Optional: Resource Manager endpoint override URL
 	RmEndpointOverride string `gcfg:"rmEndpointOverride"`
+	// Optional: PowerVS endpoint override URL
+	PowerVSEndpointOverride string `gcfg:"powerVSEndpointOverride"`
+	// Optional: Resource Controller endpoint override URL
+	RcEndpointOverride string `gcfg:"rcEndpointOverride"`
 	// PowerVSCloudInstanceID is IBM Power VS service instance id
 	PowerVSCloudInstanceID string `gcfg:"powerVSCloudInstanceID"`
 	// PowerVSCloudInstanceName is IBM Power VS service instance name

--- a/ibm/ibm_powervs_client.go
+++ b/ibm/ibm_powervs_client.go
@@ -94,12 +94,21 @@ var newPowerVSSdkClient = func(provider *Provider) (Client, error) {
 		ApiKey: credential,
 	}
 
+	// If the IAM endpoint override was specified in the config, update the URL
+	if provider.IamEndpointOverride != "" {
+		authenticator.URL = provider.IamEndpointOverride
+	}
+
 	// Create the session options struct
 	options := &ibmpisession.IBMPIOptions{
 		Authenticator: authenticator,
 		UserAccount:   provider.AccountID,
-		Region:        provider.PowerVSRegion,
 		Zone:          provider.PowerVSZone,
+	}
+
+	// If the PowerVS endpoint override was specified in the config, update the URL
+	if provider.PowerVSEndpointOverride != "" {
+		options.URL = provider.PowerVSEndpointOverride
 	}
 
 	// Construct the session service instance
@@ -110,11 +119,17 @@ var newPowerVSSdkClient = func(provider *Provider) (Client, error) {
 	}
 	client := &powerVSClient{}
 	if provider.PowerVSCloudInstanceID == "" {
-		rcv2, err := rc.NewResourceControllerV2(&rc.ResourceControllerV2Options{
+		rcOptions := &rc.ResourceControllerV2Options{
 			Authenticator: &core.IamAuthenticator{
 				ApiKey: credential,
 			},
-		})
+		}
+		// If the resource controller endpoint override was specified in the config, update the URL
+		if provider.RcEndpointOverride != "" {
+			rcOptions.URL = provider.RcEndpointOverride
+		}
+
+		rcv2, err := rc.NewResourceControllerV2(rcOptions)
 		if err != nil {
 			klog.Errorf("failed to create resource controller to fetch service instance id, error: %v", err)
 			return nil, err


### PR DESCRIPTION
PowerVS cloud provider provides ability to override endpoints like iam, vpc, resource manager, This PR adds supports to override PowerVS specific endpoints.