### PR TITLE
MULTIARCH-5055: UPSTREAM: <carry>: Reuse authenticator in resource controller options

### DIFF
--- a/ibm/ibm_powervs_client.go
+++ b/ibm/ibm_powervs_client.go
@@ -120,9 +120,7 @@ var newPowerVSSdkClient = func(provider *Provider) (Client, error) {
 	client := &powerVSClient{}
 	if provider.PowerVSCloudInstanceID == "" {
 		rcOptions := &rc.ResourceControllerV2Options{
-			Authenticator: &core.IamAuthenticator{
-				ApiKey: credential,
-			},
+			Authenticator: authenticator,
 		}
 		// If the resource controller endpoint override was specified in the config, update the URL
 		if provider.RcEndpointOverride != "" {


### PR DESCRIPTION
This PR has changes to reuse the authenticator for resource controller options, Authenticator can have iam endpoint override url.